### PR TITLE
Valid: correct the name of `imo_2006_p6` to `imo_2006_p3`

### DIFF
--- a/MiniF2F/Valid.lean
+++ b/MiniF2F/Valid.lean
@@ -81,7 +81,7 @@ theorem imo_1984_p2 (a b : ℤ) (h₀ : 0 < a ∧ 0 < b) (h₁ : ¬7 ∣ a) (h�
 theorem amc12a_2008_p4 : (∏ k ∈ Finset.Icc (1 : ℕ) 501, ((4 : ℝ) * k + 4) / (4 * k)) = 502 := by
   sorry
 
-theorem imo_2006_p6 (a b c : ℝ) :
+theorem imo_2006_p3 (a b c : ℝ) :
   a * b * (a ^ 2 - b ^ 2) + b * c * (b ^ 2 - c ^ 2) + c * a * (c ^ 2 - a ^ 2) ≤
   9 * Real.sqrt 2 / 32 * (a ^ 2 + b ^ 2 + c ^ 2) ^ 2 := by
   sorry


### PR DESCRIPTION
P6 was a geometry question about convex polygons.