### PR TITLE
Fix 7 erroneous theorem formalizations in test split

### DIFF
--- a/MiniF2F/Test/aime_1994_p3.lean
+++ b/MiniF2F/Test/aime_1994_p3.lean
@@ -6,6 +6,6 @@ open BigOperators Real Nat Topology Rat
 
 theorem aime_1994_p3
   (f : ℤ → ℤ)
-  (h0 : f x + f (x-1) = x^2)
-  (h1 : f 19 = 94):
-  f (94) % 1000 = 561 := by sorry
+  (h0 : ∀ x, f x + f (x - 1) = x^2)
+  (h1 : f 19 = 94) :
+  f 94 % 1000 = 561 := by sorry

--- a/MiniF2F/Test/algebra_ineq_nto1onlt2m1on.lean
+++ b/MiniF2F/Test/algebra_ineq_nto1onlt2m1on.lean
@@ -6,4 +6,4 @@ open BigOperators Real Nat Topology Rat
 
 theorem algebra_ineq_nto1onlt2m1on
   (n : ℕ) :
-  (n : ℝ) ^ (1 / n : ℝ) < 2 - 1 / n := by sorry
+  (n : ℝ) ^ (1 / n : ℝ) ≤ 2 - 1 / n := by sorry

--- a/MiniF2F/Test/amc12a_2019_p12.lean
+++ b/MiniF2F/Test/amc12a_2019_p12.lean
@@ -4,6 +4,6 @@ set_option maxHeartbeats 0
 
 open BigOperators Real Nat Topology Rat
 
-theorem amc12a_2019_p12 (x y : ℕ) (h₀ : x ≠ 1 ∧ y ≠ 1)
+theorem amc12a_2019_p12 (x y : ℝ) (h : x > 0 ∧ y > 0) (h₀ : x ≠ 1 ∧ y ≠ 1)
     (h₁ : Real.log x / Real.log 2 = Real.log 16 / Real.log y) (h₂ : x * y = 64) :
     (Real.log (x / y) / Real.log 2) ^ 2 = 20 := by sorry

--- a/MiniF2F/Test/amc12a_2020_p10.lean
+++ b/MiniF2F/Test/amc12a_2020_p10.lean
@@ -6,6 +6,6 @@ open BigOperators Real Nat Topology Rat
 
 theorem amc12a_2020_p10
   (n : ℕ)
-  (h₀ : 0 < n)
+  (h₀ : 1 < n)
   (h₁ : Real.logb 2 (Real.logb 16 n) = Real.logb 4 (Real.logb 4 n)) :
   (Nat.digits 10 n).sum = 13 := by sorry

--- a/MiniF2F/Test/amc12a_2021_p25.lean
+++ b/MiniF2F/Test/amc12a_2021_p25.lean
@@ -6,6 +6,7 @@ open BigOperators Real Nat Topology Rat
 
 theorem amc12a_2021_p25
   (N : ℕ)
+  (hN : N > 0)
   (f : ℕ → ℝ)
   (h₀ : ∀ n, 0 < n → f n = ((Nat.divisors n).card)/(n^((1:ℝ)/3)))
   (h₁ : ∀ n ≠ N, 0 < n → f n < f N) :

--- a/MiniF2F/Test/imo_1982_p1.lean
+++ b/MiniF2F/Test/imo_1982_p1.lean
@@ -6,7 +6,7 @@ open BigOperators Real Nat Topology Rat
 
 theorem imo_1982_p1
   (f : ℕ → ℕ)
-  (h₀ : ∀ m n, (0 < m ∧ 0 < n) → f (m + n) - f m - f n = 0 ∨ f (m + n) - f m - f n = 1)
+  (h₀ : ∀ m n, (0 < m ∧ 0 < n) → f (m + n) - f m - f n = (0 : ℤ) ∨ f (m + n) - f m - f n = (1 : ℤ))
   (h₁ : f 2 = 0)
   (h₂ : 0 < f 3)
   (h₃ : f 9999 = 3333) :

--- a/MiniF2F/Test/mathd_numbertheory_618.lean
+++ b/MiniF2F/Test/mathd_numbertheory_618.lean
@@ -6,6 +6,7 @@ open BigOperators Real Nat Topology Rat
 
 theorem mathd_numbertheory_618
   (n : ℕ)
+  (hn : n > 0)
   (p : ℕ → ℕ)
   (h₀ : ∀ x, p x = x^2 - x + 41)
   (h₁ : 1 < Nat.gcd (p n) (p (n+1))) :


### PR DESCRIPTION
## Summary

Fixes 7 incorrect theorem formalizations in `MiniF2F/Test/` that are either unprovable or mathematically wrong.

Six of these were previously identified and corrected by the [NuminaMath](https://huggingface.co/datasets/AI-MO/minif2f_test) project (based on [DeepSeek-Prover-V1.5](https://github.com/deepseek-ai/DeepSeek-Prover-V1.5)). One additional bug (`algebra_ineq_nto1onlt2m1on`) was found independently by us through systematic comparison of the upstream yangky11/miniF2F-lean4 formalizations against the NuminaMath dataset.

## Detailed fixes

### From NuminaMath corrections (6 theorems)

#### 1. `mathd_numbertheory_618` — Add missing `n > 0` guard

**Problem:** Without `(hn : n > 0)`, the theorem has a counterexample at `n = 0`:
- `p(0) = 0² - 0 + 41 = 41`
- `p(1) = 1² - 1 + 41 = 41`
- `gcd(41, 41) = 41 > 1` → hypothesis `h₁` is satisfied
- But conclusion `41 ≤ 0` is **false**

**Fix:** Add `(hn : n > 0)` hypothesis.

#### 2. `aime_1994_p3` — Add missing `∀ x` quantifier

**Problem:** The hypothesis `(h0 : f x + f (x-1) = x^2)` has `x` as a free variable that Lean auto-binds as an implicit argument. This means `h0` constrains `f` at only **one** value of `x`, not all integers. A single equation `f(x₀) + f(x₀-1) = x₀²` cannot determine `f(94)`, so the theorem is unprovable.

**Fix:** Change to `(h0 : ∀ x, f x + f (x - 1) = x^2)`.

#### 3. `amc12a_2020_p10` — Strengthen `0 < n` to `1 < n`

**Problem:** At `n = 1`:
- `logb 16 1 = 0`, and in Lean `Real.log 0 = 0`
- `logb 2 (logb 16 1) = logb 2 0 = 0`
- `logb 4 (logb 4 1) = logb 4 0 = 0`
- So `h₁` is satisfied (0 = 0), but `digit_sum(1) = 1 ≠ 13`

**Fix:** Change `(h₀ : 0 < n)` to `(h₀ : 1 < n)`.

#### 4. `amc12a_2019_p12` — Change variable types from `ℕ` to `ℝ`, add positivity

**Problem:** The original AMC 12A 2019 Problem 12 is about real numbers. With `x y : ℕ`:
- `x / y` is **truncating integer division** (e.g., `4 / 16 = 0` in `ℕ`)
- `Real.log 0 = 0` in Lean, so `(log(0) / log(2))² = 0 ≠ 20`
- No pair of natural numbers `(x, y)` with `x * y = 64` gives the correct answer

**Fix:** Change to `(x y : ℝ) (h : x > 0 ∧ y > 0)`.

#### 5. `amc12a_2021_p25` — Add missing `N > 0` guard

**Problem:** Without `(hN : N > 0)`, at `N = 0`:
- `h₀` only constrains `f(n)` for `n > 0`, leaving `f(0)` free
- `Nat.divisors 0 = ∅` in Mathlib, so `f(0)` via `h₀` would be `0/0 = 0`
- But `h₁` requires `f(n) < f(0)` for all `n > 0`, while `f(1) = 1/1 = 1 > 0 = f(0)`
- Conclusion `digit_sum(0) = 0 ≠ 9` is false

**Fix:** Add `(hN : N > 0)` hypothesis.

#### 6. `imo_1982_p1` — Add `ℤ` type annotations for subtraction

**Problem:** Without `(0 : ℤ)` / `(1 : ℤ)` annotations, the expressions `f (m + n) - f m - f n` use `ℕ` truncated subtraction (where negative results become 0). This makes the hypothesis strictly weaker than intended:
- Example: `f(m+n) = 5, f(m) = 3, f(n) = 4`
- In `ℤ`: `5 - 3 - 4 = -2` (not 0 or 1, so this `f` would be rejected)
- In `ℕ`: `(5 - 3) - 4 = 2 - 4 = 0` (truncated, **incorrectly** satisfies `= 0` case)

**Fix:** Add `(0 : ℤ)` and `(1 : ℤ)` type annotations to force integer subtraction.

### Found independently (1 theorem)

#### 7. `algebra_ineq_nto1onlt2m1on` — Change `<` to `≤`

**Problem:** At `n = 1`:
- `1^(1/1) = 1` and `2 - 1/1 = 1`
- `1 < 1` is **false**, but `1 ≤ 1` is true

This bug was **not** caught by NuminaMath and was found by us through independent analysis.

**Fix:** Change `<` to `≤`.

## References

- NuminaMath corrections: https://huggingface.co/datasets/AI-MO/minif2f_test
- DeepSeek-Prover-V1.5 modifications: https://github.com/deepseek-ai/DeepSeek-Prover-V1.5